### PR TITLE
fix: returns an array instead of an object

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -64,7 +64,7 @@ class Database {
     {
         return count($this->result) > 0
             ? $this->result[0]
-            : [];
+            : new \stdClass;
     }
 
     /**


### PR DESCRIPTION
Hello,

During our developments using your library, we noticed that when we use the "getFirstResult" function present in the "Database" class, in case of empty result, a PHP exception is raised.

This is due to the fact that you specify a return in object, but in the case of an empty result, it is an array that is returned.

We have modified your class so that it returns an object according to the typing in place.

Have a nice day,
The Solar Screen team