### PR TITLE
Add Authorization

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -29,6 +29,7 @@ class Service {
 
         $this->httpClient = new \GuzzleHttp\Client();
         $this->headers['apikey'] = $this->apiKey;
+        $this->headers['Authorization'] = 'Bearer ' . $this->apiKey;
     }
 
     /**


### PR DESCRIPTION
After starting Bot and Abuse Protection, you need to add Authorization, otherwise captcha verification process failed will be reported.