### PR TITLE
fix: getError return type

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -33,7 +33,7 @@ class Auth {
      * @access public
      * @return string
      */
-    public function getError() : string
+    public function getError() : string|null
     {
         return $this->service->getError();
     }

--- a/src/Service.php
+++ b/src/Service.php
@@ -138,7 +138,7 @@ class Service {
      * @access public
      * @return string
      */
-    public function getError() : string
+    public function getError() : string|null
     {
         return $this->error;
     }


### PR DESCRIPTION
This fixes the return type for the function since the supabase itself may return null and not a string