### PR TITLE
Add port to Uri base

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -75,7 +75,7 @@ class Service {
     public function getUriBase(string $endPoint = '') : string
     {
         $parseUrl = parse_url($this->uriBase);
-        return $parseUrl['scheme'] . '://' . $parseUrl['host'] . '/' . $endPoint;
+        return $parseUrl['scheme'] . '://' . $parseUrl['host'] . ':' . $parseUrl['port'] . '/' . $endPoint;
     }
 
     /**


### PR DESCRIPTION
Add a port to the Uri base, to allow for Uris that point to endpoints at ports different than 80. Useful for development, where the endpoint could be at localhost:8001/auth/v1