### PR TITLE
Fix deprecation warnings in PHP 8.4

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -224,7 +224,7 @@ class Auth {
      * @param array  $data Optional. The user meta data
      * @return array|object|null
      */
-    public function updateUser(string $bearerUserToken, string $email = null, string $password = null, array $data = [])
+    public function updateUser(string $bearerUserToken, ?string $email = null, ?string $password = null, array $data = [])
     {
         $uri = $this->service->getUriBase($this->suffix . 'user');
         $this->service->setHeader('Authorization', 'Bearer ' . $bearerUserToken);

--- a/src/Database.php
+++ b/src/Database.php
@@ -75,7 +75,7 @@ class Database {
      * @param string $table String Optional. Use a different table that the set in construct method
      * @return void
      */
-    private function executeQuery(string $queryString, string $table = null) : void
+    private function executeQuery(string $queryString, ?string $table = null) : void
     {
         $table = is_null($table)
                 ? $this->tableName
@@ -95,7 +95,7 @@ class Database {
      * @param string $queryString Optional. The parameters to be used in the requests
      * @return array|object|null
      */
-    private function executeDml(string $method, array $data, string $queryString = null)
+    private function executeDml(string $method, array $data, ?string $queryString = null)
     {
         $endPoint = ($queryString == null) ? $this->tableName : $this->tableName . '?' . $queryString; 
         $uri = $this->service->getUriBase($this->suffix . $endPoint);

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -96,7 +96,7 @@ class QueryBuilder {
      * @param string $select Optional. The columns to be select in foreign table
      * @return QueryBuilder
      */
-    public function join(string $table, string $tablekey, string $select = null) : QueryBuilder
+    public function join(string $table, string $tablekey, ?string $select = null) : QueryBuilder
     {
         $this->query['join'][] = $table . 
                                 '(' . $tablekey . ',' .


### PR DESCRIPTION
I got these warnings when using this package:
```
Deprecated: PHPSupabase\Database::executeQuery(): Implicitly marking parameter $table as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/rafaelwendel/phpsupabase/src/Database.php on line 78

Deprecated: PHPSupabase\Database::executeDml(): Implicitly marking parameter $queryString as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/rafaelwendel/phpsupabase/src/Database.php on line 98
```
In PHP 9, this will become an error.