### PR TITLE
feat: Add error handling for PostgREST responses in Database and QueryBuilder

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -53,6 +53,9 @@ class Database {
      */
     public function getResult() : array
     {
+        if ($this->service->isPostgrestError($this->result)) {
+            return throw new Exception($this->result->message);
+        }
         return $this->result;
     }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -39,6 +39,9 @@ class QueryBuilder {
      */
     public function getResult() : array
     {
+        if ($this->service->isPostgrestError($this->result)) {
+            return throw new Exception($this->result->message);
+        }
         return $this->result;
     }
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -159,6 +159,27 @@ class Service
     }
 
     /**
+     * Check if the last response contains an error
+     * @access public
+     * @return bool
+     */
+    public function hasError(): bool
+    {
+        return !is_null($this->error);
+    }
+
+    /**
+     * Check if the response is a PostgREST error
+     * @access public
+     * @param mixed $response The response to check
+     * @return bool
+     */
+    public function isPostgrestError($response): bool
+    {
+        return is_object($response) && isset($response->code) && isset($response->message);
+    }
+
+    /**
      * Returns a new instance of Auth class
      * @access public
      * @return Auth


### PR DESCRIPTION
I encountered a lot of issues without really knowing what was going wrong, which was quite frustrating.  
So I tried to implement a clearer understanding of the errors.

Previously, you would get something like:
```bash
In QueryBuilder.php line 42:
  PHPSupabase\QueryBuilder::getResult(): Return value must be of type array, stdClass returned
````

Now, you’ll get a more detailed message:

```bash
[ERROR] Error during synchronization: Could not embed because more than one relationship was found for
         'exploration' and 'users'
```

We could go deeper to improve this further, but I think this first step already helps a lot without breaking too much of the existing logic.