### PR TITLE
feat: Add AuthAdmin class for /auth/v1/admin/* endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ index.php
 tabletestes.php
 querybuildertests.php
 composer.lock
+.phpunit.cache
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes in PHPSupabase #
 
+## Unreleased
+
+- Add `AuthAdmin` class to wrap the Supabase admin auth API (`/auth/v1/admin/*`). Covers `createUser` (bypasses `disable_signup`), `listUsers`, `getUser`, `updateUser` (incl. ban/unban), `deleteUser` and `generateLink`. Requires the project `service_role` key.
+- Add PHPUnit test infrastructure (`phpunit/phpunit` ^10) and unit tests for `AuthAdmin` using Guzzle's `MockHandler`.
+    - Credit to @Snowbaha for contribution
+
 ## 0.0.11 - 2025-10-28
 
 - Add error handling for PostgREST responses in Database and QueryBuilder

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ PHPSupabase is a library written in php language, which allows you to use the re
         - [Sign in with email and password](#sign-in-with-email-and-password)
         - [Get the data of the logged in user](#get-the-data-of-the-logged-in-user)
         - [Update user data](#update-user-data)
+    - [AuthAdmin class (admin API)](#authadmin-class-admin-api)
+        - [Create a user (bypassing disable_signup)](#create-a-user-bypassing-disable_signup)
+        - [List, get, update and delete users](#list-get-update-and-delete-users)
+        - [Generate links (recovery, magiclink, invite, ...)](#generate-links-recovery-magiclink-invite-)
     - [Database class](#database-class)
         - [Insert data](#insert-data)
         - [Update data](#update-data)
@@ -182,6 +186,70 @@ catch(Exception $e){
 }
 ```
 Note that in the array returned now, the keys `first_name` and `last_name` were added to `user_metadata`.
+
+### AuthAdmin class (admin API)
+
+The `AuthAdmin` class wraps the Supabase admin endpoints (`/auth/v1/admin/*`). These endpoints **require the project `service_role` key** (not the anon key) and bypass restrictions such as `disable_signup`. They are intended to be called from a trusted backend, never from a public client.
+
+The `service_role` key is sent both as the `apikey` header (handled by `Service`) and as `Authorization: Bearer <service_role>` (set by `AuthAdmin` at construction time).
+
+```php
+$service = new PHPSupabase\Service(
+    "YOUR_SERVICE_ROLE_KEY",
+    "https://aaabbbccc.supabase.co"
+);
+
+$authAdmin = $service->createAuthAdmin();
+```
+
+#### Create a user (bypassing disable_signup)
+
+```php
+try {
+    $authAdmin->createUser(
+        'newuser@email.com',
+        'strong-password',
+        true,                         // email_confirm: marks email as already verified
+        ['first_name' => 'Michael']   // user_metadata
+    );
+    print_r($authAdmin->data());
+} catch (Exception $e) {
+    echo $authAdmin->getError();
+}
+```
+
+#### List, get, update and delete users
+
+```php
+// List users (paginated)
+$authAdmin->listUsers(1, 50);
+$users = $authAdmin->data()->users;
+
+// Get a single user
+$authAdmin->getUser('user-uuid');
+
+// Update a user — any subset of attributes can be passed
+$authAdmin->updateUser('user-uuid', [
+    'email'         => 'new@email.com',
+    'password'      => 'new-password',
+    'user_metadata' => ['role' => 'editor'],
+    'ban_duration'  => '24h',  // ban (use 'none' to unban)
+]);
+
+// Delete a user
+$authAdmin->deleteUser('user-uuid');
+```
+
+#### Generate links (recovery, magiclink, invite, ...)
+
+```php
+$authAdmin->generateLink('recovery', 'user@email.com', [
+    'redirect_to' => 'https://your-app.com/reset-password',
+]);
+$actionLink = $authAdmin->data()->action_link;
+```
+
+Supported `type` values: `signup`, `magiclink`, `recovery`, `invite`, `email_change_current`, `email_change_new`.
 
 ### Database class
 

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,20 @@
     "require": {
         "guzzlehttp/guzzle": "^7.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
+    },
     "autoload": {
         "psr-4": {
             "PHPSupabase\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PHPSupabase\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/AuthAdmin.php
+++ b/src/AuthAdmin.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace PHPSupabase;
+
+class AuthAdmin {
+    private $suffix = 'auth/v1/admin/';
+    private $service;
+    private $data;
+
+    /**
+     * Construct method (Set the Service instance)
+     *
+     * The Service instance must be created with the project service_role key
+     * (not the anon/public key), since the /auth/v1/admin/* endpoints require
+     * elevated privileges. The service_role is sent in both the apikey header
+     * (already handled by Service) and the Authorization Bearer header
+     * (set here at construction time).
+     *
+     * @access public
+     * @param Service $service The Supabase Service instance, built with the service_role key
+     * @return void
+     */
+    public function __construct(Service $service)
+    {
+        $this->service = $service;
+        $this->service->setHeader('Authorization', 'Bearer ' . $service->getApiKey());
+    }
+
+    /**
+     * Returns the response data produced by a requisition
+     * @access public
+     * @return object
+     */
+    public function data() : object
+    {
+        return $this->data;
+    }
+
+    /**
+     * Returns the error generated
+     * @access public
+     * @return string|null
+     */
+    public function getError() : string|null
+    {
+        return $this->service->getError();
+    }
+
+    /**
+     * Build the request options array, optionally with a JSON body
+     * @access private
+     * @param array $fields Optional. Body fields to be JSON-encoded
+     * @return array
+     */
+    private function buildOptions(array $fields = []) : array
+    {
+        $options = ['headers' => $this->service->getHeaders()];
+        if(count($fields) > 0){
+            $options['body'] = json_encode($fields);
+        }
+        return $options;
+    }
+
+    /**
+     * Create a new user via the admin endpoint (bypasses disable_signup)
+     * @access public
+     * @param string $email The email address of the new user
+     * @param string $password The password of the new user
+     * @param bool $emailConfirm Optional. If true, marks the email as confirmed (default: true)
+     * @param array $userMetadata Optional. The user metadata
+     * @return void
+     */
+    public function createUser(string $email, string $password, bool $emailConfirm = true, array $userMetadata = []) : void
+    {
+        $fields = [
+            'email' => $email,
+            'password' => $password,
+            'email_confirm' => $emailConfirm
+        ];
+        if(is_array($userMetadata) && count($userMetadata) > 0){
+            $fields['user_metadata'] = $userMetadata;
+        }
+
+        $uri = $this->service->getUriBase($this->suffix . 'users');
+        $this->data = $this->service->executeHttpRequest('POST', $uri, $this->buildOptions($fields));
+    }
+
+    /**
+     * List users with pagination
+     * @access public
+     * @param int $page Optional. Page number (default: 1)
+     * @param int $perPage Optional. Items per page (default: 50)
+     * @return void
+     */
+    public function listUsers(int $page = 1, int $perPage = 50) : void
+    {
+        $query = http_build_query(['page' => $page, 'per_page' => $perPage]);
+        $uri = $this->service->getUriBase($this->suffix . 'users') . '?' . $query;
+        $this->data = $this->service->executeHttpRequest('GET', $uri, $this->buildOptions());
+    }
+
+    /**
+     * Get a user by id
+     * @access public
+     * @param string $userId The user id
+     * @return void
+     */
+    public function getUser(string $userId) : void
+    {
+        $uri = $this->service->getUriBase($this->suffix . 'users/' . $userId);
+        $this->data = $this->service->executeHttpRequest('GET', $uri, $this->buildOptions());
+    }
+
+    /**
+     * Update a user (email, password, user_metadata, app_metadata, ban_duration, ...)
+     * @access public
+     * @param string $userId The user id
+     * @param array $attributes The attributes to update (ex: ['email' => '...', 'password' => '...', 'user_metadata' => [...], 'ban_duration' => '24h'])
+     * @return void
+     */
+    public function updateUser(string $userId, array $attributes) : void
+    {
+        $uri = $this->service->getUriBase($this->suffix . 'users/' . $userId);
+        $this->data = $this->service->executeHttpRequest('PUT', $uri, $this->buildOptions($attributes));
+    }
+
+    /**
+     * Delete a user by id
+     * @access public
+     * @param string $userId The user id
+     * @return void
+     */
+    public function deleteUser(string $userId) : void
+    {
+        $uri = $this->service->getUriBase($this->suffix . 'users/' . $userId);
+        $this->data = $this->service->executeHttpRequest('DELETE', $uri, $this->buildOptions());
+    }
+
+    /**
+     * Generate a link (signup, magiclink, recovery, invite, email_change_current, email_change_new)
+     * @access public
+     * @param string $type The link type (signup, magiclink, recovery, invite, email_change_current, email_change_new)
+     * @param string $email The user email
+     * @param array $options Optional. Additional options (ex: ['password' => '...', 'data' => [...], 'redirect_to' => '...'])
+     * @return void
+     */
+    public function generateLink(string $type, string $email, array $options = []) : void
+    {
+        $fields = array_merge(['type' => $type, 'email' => $email], $options);
+        $uri = $this->service->getUriBase($this->suffix . 'generate_link');
+        $this->data = $this->service->executeHttpRequest('POST', $uri, $this->buildOptions($fields));
+    }
+}

--- a/src/Service.php
+++ b/src/Service.php
@@ -190,6 +190,20 @@ class Service
     }
 
     /**
+     * Returns a new instance of AuthAdmin class
+     *
+     * The Service instance must have been built with the project service_role key,
+     * since the /auth/v1/admin/* endpoints require elevated privileges.
+     *
+     * @access public
+     * @return AuthAdmin
+     */
+    public function createAuthAdmin(): AuthAdmin
+    {
+        return new AuthAdmin($this);
+    }
+
+    /**
      * Returns a new instance of Database class
      * @access public
      * @param string $tableName The table to be used

--- a/tests/AuthAdminTest.php
+++ b/tests/AuthAdminTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace PHPSupabase\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPSupabase\AuthAdmin;
+use PHPSupabase\Service;
+use PHPUnit\Framework\TestCase;
+
+class AuthAdminTest extends TestCase
+{
+    private const SERVICE_ROLE_KEY = 'fake-service-role-key';
+    private const URI_BASE = 'https://abc.supabase.co/auth/v1/';
+
+    /** @var array<int, array{request: Request, response: Response}> */
+    private array $history = [];
+
+    private Service $service;
+    private AuthAdmin $authAdmin;
+
+    /**
+     * Build a Service instance whose internal Guzzle client is replaced by a mocked one
+     * driven by the provided response queue, and the AuthAdmin built on top of it.
+     *
+     * @param array<int, mixed> $responses Queue of Response or Throwable to be returned by the mock handler
+     */
+    private function setUpWithResponses(array $responses): void
+    {
+        $mock = new MockHandler($responses);
+        $stack = HandlerStack::create($mock);
+        $this->history = [];
+        $stack->push(Middleware::history($this->history));
+        $client = new Client(['handler' => $stack]);
+
+        $this->service = new Service(self::SERVICE_ROLE_KEY, self::URI_BASE);
+
+        $ref = new \ReflectionProperty(Service::class, 'httpClient');
+        $ref->setValue($this->service, $client);
+
+        $this->authAdmin = $this->service->createAuthAdmin();
+    }
+
+    private function lastRequest(): Request
+    {
+        $last = end($this->history);
+        return $last['request'];
+    }
+
+    public function testServiceCreateAuthAdminReturnsAuthAdminInstance(): void
+    {
+        $service = new Service(self::SERVICE_ROLE_KEY, self::URI_BASE);
+        $this->assertInstanceOf(AuthAdmin::class, $service->createAuthAdmin());
+    }
+
+    public function testCreateUserSendsCorrectRequest(): void
+    {
+        $body = json_encode(['id' => 'user-123', 'email' => 'a@b.c']);
+        $this->setUpWithResponses([new Response(200, [], $body)]);
+
+        $this->authAdmin->createUser('a@b.c', 'pwd', true, ['name' => 'Alice']);
+
+        $req = $this->lastRequest();
+        $this->assertSame('POST', $req->getMethod());
+        $this->assertStringEndsWith('/auth/v1/admin/users', (string) $req->getUri());
+
+        $this->assertSame(self::SERVICE_ROLE_KEY, $req->getHeaderLine('apikey'));
+        $this->assertSame('Bearer ' . self::SERVICE_ROLE_KEY, $req->getHeaderLine('Authorization'));
+        $this->assertSame('application/json', $req->getHeaderLine('Content-Type'));
+
+        $payload = json_decode((string) $req->getBody(), true);
+        $this->assertSame('a@b.c', $payload['email']);
+        $this->assertSame('pwd', $payload['password']);
+        $this->assertTrue($payload['email_confirm']);
+        $this->assertSame(['name' => 'Alice'], $payload['user_metadata']);
+
+        $this->assertSame('user-123', $this->authAdmin->data()->id);
+    }
+
+    public function testCreateUserOmitsEmptyUserMetadata(): void
+    {
+        $this->setUpWithResponses([new Response(200, [], '{}')]);
+
+        $this->authAdmin->createUser('a@b.c', 'pwd');
+
+        $payload = json_decode((string) $this->lastRequest()->getBody(), true);
+        $this->assertArrayNotHasKey('user_metadata', $payload);
+        $this->assertTrue($payload['email_confirm']);
+    }
+
+    public function testCreateUserCanDisableEmailConfirm(): void
+    {
+        $this->setUpWithResponses([new Response(200, [], '{}')]);
+
+        $this->authAdmin->createUser('a@b.c', 'pwd', false);
+
+        $payload = json_decode((string) $this->lastRequest()->getBody(), true);
+        $this->assertFalse($payload['email_confirm']);
+    }
+
+    public function testCreateUserHandlesEmailAlreadyRegistered(): void
+    {
+        $this->setUpWithResponses([
+            new Response(422, [], json_encode([
+                'msg' => 'A user with this email address has already been registered',
+            ])),
+        ]);
+
+        $this->expectException(ClientException::class);
+
+        try {
+            $this->authAdmin->createUser('existing@b.c', 'pwd');
+        } finally {
+            $this->assertSame(
+                'A user with this email address has already been registered',
+                $this->authAdmin->getError()
+            );
+        }
+    }
+
+    public function testCreateUserHandlesNetworkError(): void
+    {
+        $this->setUpWithResponses([
+            new ConnectException('Connection refused', new Request('POST', 'https://abc.supabase.co')),
+        ]);
+
+        $this->expectException(ConnectException::class);
+
+        try {
+            $this->authAdmin->createUser('a@b.c', 'pwd');
+        } finally {
+            $this->assertSame('Connection refused', $this->authAdmin->getError());
+        }
+    }
+
+    public function testListUsersSendsGetWithPagination(): void
+    {
+        $this->setUpWithResponses([new Response(200, [], '{"users": []}')]);
+
+        $this->authAdmin->listUsers(2, 25);
+
+        $req = $this->lastRequest();
+        $this->assertSame('GET', $req->getMethod());
+        $this->assertStringContainsString('/auth/v1/admin/users', (string) $req->getUri());
+        $this->assertStringContainsString('page=2', $req->getUri()->getQuery());
+        $this->assertStringContainsString('per_page=25', $req->getUri()->getQuery());
+    }
+
+    public function testGetUserReturnsUserData(): void
+    {
+        $this->setUpWithResponses([new Response(200, [], '{"id": "user-123", "email": "a@b.c"}')]);
+
+        $this->authAdmin->getUser('user-123');
+
+        $req = $this->lastRequest();
+        $this->assertSame('GET', $req->getMethod());
+        $this->assertStringEndsWith('/auth/v1/admin/users/user-123', (string) $req->getUri());
+        $this->assertSame('user-123', $this->authAdmin->data()->id);
+        $this->assertSame('a@b.c', $this->authAdmin->data()->email);
+    }
+
+    public function testUpdateUserSendsPutWithAttributes(): void
+    {
+        $this->setUpWithResponses([new Response(200, [], '{"id":"user-123"}')]);
+
+        $this->authAdmin->updateUser('user-123', [
+            'email' => 'new@b.c',
+            'ban_duration' => '24h',
+            'user_metadata' => ['role' => 'admin'],
+        ]);
+
+        $req = $this->lastRequest();
+        $this->assertSame('PUT', $req->getMethod());
+        $this->assertStringEndsWith('/auth/v1/admin/users/user-123', (string) $req->getUri());
+
+        $payload = json_decode((string) $req->getBody(), true);
+        $this->assertSame('new@b.c', $payload['email']);
+        $this->assertSame('24h', $payload['ban_duration']);
+        $this->assertSame(['role' => 'admin'], $payload['user_metadata']);
+    }
+
+    public function testDeleteUserSendsDelete(): void
+    {
+        $this->setUpWithResponses([new Response(200, [], '{}')]);
+
+        $this->authAdmin->deleteUser('user-123');
+
+        $req = $this->lastRequest();
+        $this->assertSame('DELETE', $req->getMethod());
+        $this->assertStringEndsWith('/auth/v1/admin/users/user-123', (string) $req->getUri());
+    }
+
+    public function testGenerateLinkSendsPostWithTypeAndOptions(): void
+    {
+        $this->setUpWithResponses([new Response(200, [], '{"action_link":"https://abc.supabase.co/recover"}')]);
+
+        $this->authAdmin->generateLink('recovery', 'a@b.c', ['redirect_to' => 'https://app.com/reset']);
+
+        $req = $this->lastRequest();
+        $this->assertSame('POST', $req->getMethod());
+        $this->assertStringEndsWith('/auth/v1/admin/generate_link', (string) $req->getUri());
+
+        $payload = json_decode((string) $req->getBody(), true);
+        $this->assertSame('recovery', $payload['type']);
+        $this->assertSame('a@b.c', $payload['email']);
+        $this->assertSame('https://app.com/reset', $payload['redirect_to']);
+    }
+
+    public function testServerErrorIsRethrownWithFormattedError(): void
+    {
+        $this->setUpWithResponses([
+            new Response(500, [], json_encode(['error_description' => 'Internal server error'])),
+        ]);
+
+        $this->expectException(ServerException::class);
+
+        try {
+            $this->authAdmin->getUser('user-123');
+        } finally {
+            $this->assertSame('Internal server error', $this->authAdmin->getError());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add an `AuthAdmin` class that wraps the Supabase admin auth API (`/auth/v1/admin/*`). These endpoints are only callable with the project `service_role` key and bypass restrictions such as `disable_signup`. They cover use cases the public `Auth` endpoints cannot:

- creating a user from a trusted backend even when public signup is disabled
- listing / getting / updating / deleting users with elevated privileges
- generating magic links / recovery / invite links server-side
- banning users (via `ban_duration` on `updateUser`)

Without this, those endpoints can only be reached by bypassing the library and going to Guzzle directly — duplicating the auth client logic.

## What's added

- **`PHPSupabase\AuthAdmin`** (new) — 6 methods, suffix `auth/v1/admin/`
  - `createUser(email, password, emailConfirm = true, userMetadata = [])`
  - `listUsers(page = 1, perPage = 50)`
  - `getUser(userId)`
  - `updateUser(userId, attributes)` — supports email / password / metadata / ban
  - `deleteUser(userId)`
  - `generateLink(type, email, options = [])`
- **`Service::createAuthAdmin()`** — factory, mirrors the existing `createAuth()`
- **`tests/AuthAdminTest.php`** — 12 tests, 40 assertions, using Guzzle's `MockHandler` to verify URLs, headers, request bodies and error handling (HTTP 4xx / 5xx / network)
- **PHPUnit infrastructure** : `phpunit/phpunit ^10` in `require-dev`, `phpunit.xml`, `composer test` script, `autoload-dev` for `PHPSupabase\Tests\` namespace
- **README** : new section "AuthAdmin class (admin API)" with usage examples
- **CHANGELOG** : entry under "Unreleased"

## How the `service_role` key is forwarded

`Service` already injects the API key as the `apikey` header at construction. `AuthAdmin::__construct` additionally sets `Authorization: Bearer <service_role>` on the same `Service` headers — both are required by Supabase admin endpoints.

The caller is responsible for instantiating `Service` with the service_role key (not the anon key); this is documented in the new README section.

## Backward compatibility

- No existing API is changed. `Auth` is untouched.
- New `phpunit` dev dependency: PHP 8.1+ for contributors only — does not affect library users (no PHP version requirement added to `require`).
- No new runtime dependency.

## Tests

```sh
composer install && composer test
```
→ 12 tests pass.